### PR TITLE
Fix broken external link

### DIFF
--- a/content/content-strategy/cstudies.md
+++ b/content/content-strategy/cstudies.md
@@ -4,6 +4,6 @@ cards:
   - image: /content-strategy/content-experts.jpg
     headline: How we're working
     text: We have come together with over 30 government agencies to produce guidance that helps government teams implement their own content strategy.
-    link: https://www.dta.gov.au/what-we-do/platforms/govau/
+    link: https://www.dta.gov.au/what-we-do/platforms/content-strategy/
     cta: Read on DTA site
 ---


### PR DESCRIPTION
Card link under examples/case studies now points to valid external page.