### PR TITLE
Add ‘Understand user needs’ criterion topic

### DIFF
--- a/content/standard/understand-user-needs/guidance-head.md
+++ b/content/standard/understand-user-needs/guidance-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Guidance related to this criterion
+---

--- a/content/standard/understand-user-needs/guidance.md
+++ b/content/standard/understand-user-needs/guidance.md
@@ -1,0 +1,8 @@
+---
+layout: cards/cards
+cards:
+  - headline: Discovery Guide
+    text: Old DTO Service Handbook: Discovery
+    link: '#url'
+    cta: View on DTO Github
+---

--- a/content/standard/understand-user-needs/guidance.md
+++ b/content/standard/understand-user-needs/guidance.md
@@ -4,5 +4,9 @@ cards:
   - headline: Discovery Guide
     text: Old DTO Service Handbook: Discovery
     link: '#url'
-    cta: View on DTO Github
+    cta: View on AusDTO Github
+  - headline: Alpha Guide
+    text: Old DTO Service Handbook: Alpha
+    link: '#url'
+    cta: View on AusDTO Github
 ---

--- a/content/standard/understand-user-needs/how-head.md
+++ b/content/standard/understand-user-needs/how-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: How you'll be assessed
+---

--- a/content/standard/understand-user-needs/how.md
+++ b/content/standard/understand-user-needs/how.md
@@ -1,0 +1,24 @@
+---
+layout: text/textblock
+---
+#### In Discovery and Alpha
+During the Discovery and Alpha stages the entire team should have spent a lot of time with end users and learned a lot about their needs. You should understand and be able to show evidence to demonstrate:
+ -  **Who are the users?** What about their motivations, triggers, contexts are significant for your service? How can you find them to invite them to participate in user research? You must include users with varying needs (such as needs arising from disability, cultural diversity, literacy and remoteness). Consider all the users in the service including end users, users in government who are delivering the service, and key intermediaries (professional and personal network)
+ -  **What is the real task(s) that people are trying to achieve** when they encounter your service. What is the ‘job’ people are trying to get done that your service is a part of? (You need to describe this in words that real end users would use, not using government terminology)
+ -  **How are users currently doing the task** your service aims to help them do and key touch points, for example through journey maps. What other relevant government and non-government services are also in use at this time? Where are the pain points in the current experience?
+ -  **What are the user needs?** What are the opportunities to remove or reduce the pain points? How might we better meet the user needs? (Demonstrate this through research, testing and validating possible solutions with prototypes)
+ -  **Are you designing the right thing?** How have your insights from user research helped you to define your minimum viable product (MVP)? How does the MVP create value for users and government by better meeting user needs?
+
+#### During Beta
+During the Beta stage your understanding of what your users value will have matured through testing design prototypes with them. By the end of the Beta stage you should be able to show:
+-  Greater depth and diversity of knowledge on all of the points above from Alpha/Beta as well as
+-  **How has your service been shaped by user needs?** Show how you have made changes in the service and interaction design in response to user research and usability testing. You can evidence this by showing how the design has changed over time and the appropriate research findings that have driven this change
+-  **How you tested the system in the users’ context with a full range of users** (including users with varying needs). You can evidence this with artefacts of research, for example, video clips and outcomes from research analysis
+-  **Are you prepared for ongoing user research?** Show how you plan to continue to test the system with users and the resources for this, for example through an ongoing research plan and budget
+-  **What have you not solved yet?** What the significant design challenges are, for example through key insights, how have you approached them? How do you plan to continue to tackle them?
+-  **How will you know if your design is working?** Make sure that research has fed into the metrics you have developed to know that you continue to meet your user needs.
+
+By the time you are ready to go live you should:
+-  Be able to show greater depth of knowledge for all the points above as well as
+-  **Show how you are using data from real use** to understand which parts of the task users are finding difficult and how you are designing experiments to reduce friction and increase success for users
+-  Know how you will measure and monitor your service to ensure it is serving its users well.

--- a/content/standard/understand-user-needs/index.yml
+++ b/content/standard/understand-user-needs/index.yml
@@ -14,8 +14,8 @@ main:
   - how.md
   - guidance-head.md
   - guidance.md
-  - cstudies-section.md
-  - cstudies.md
+  #- cstudies-section.md
+  #- cstudies.md
   - /_shared/feedback.md
 footer:
   - /_shared/footer-gds.md

--- a/content/standard/understand-user-needs/index.yml
+++ b/content/standard/understand-user-needs/index.yml
@@ -1,0 +1,21 @@
+title: 1. Understand user needs
+weight: 20
+layout: layout/topic
+theme: blue
+header:
+  - /_shared/globalheader.md
+  - /_shared/header.md
+main:
+  - intro.md
+  - toc.md
+  - why-head.md
+  - why.md
+  - how-head.md
+  - how.md
+  - guidance-head.md
+  - guidance.md
+  - cstudies-section.md
+  - cstudies.md
+  - /_shared/feedback.md
+footer:
+  - /_shared/footer-gds.md

--- a/content/standard/understand-user-needs/intro.md
+++ b/content/standard/understand-user-needs/intro.md
@@ -1,0 +1,5 @@
+---
+layout: intros/intro
+category: Digital Service Standard
+subtitle: Understand user needs. Research to develop a deep knowledge of the users and their context for using the service.
+---

--- a/content/standard/understand-user-needs/toc.md
+++ b/content/standard/understand-user-needs/toc.md
@@ -1,0 +1,9 @@
+---
+layout: nav/sections
+title: Contents
+sections:
+  - Why it's in the Standard
+  - How you'll be assessed
+  - Guidance related to this criterion
+  - Further reading
+---

--- a/content/standard/understand-user-needs/why-head.md
+++ b/content/standard/understand-user-needs/why-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Why it's in the Standard
+---

--- a/content/standard/understand-user-needs/why.md
+++ b/content/standard/understand-user-needs/why.md
@@ -1,0 +1,10 @@
+---
+layout: text/textblock
+---
+You need to understand the people who use your service (your users) and what they want to do (their user needs) in order to build a service that works for them. You need to understand users and their needs from their point of view and not solely through the lens of the project you have been tasked with.
+
+To do this, you will need to really understand what users are trying to do when they encounter your part of the service and you need to design services that address that context. This will often involve understanding things that are not ‘in scope’ or part of your responsibility so that you can design better services.
+
+You will need to understand all aspects (end to end and across channels) of your users’ current experience. You should include as users everyone who is involved in the service delivery: end users, public servants delivering the service and other intermediaries who support end users to access the service.
+
+Your user research needs to cover a wide range of users and show that you understand how different user scenarios may impact service design and delivery. You must include from the earliest stages users who may need assistance to interact digitally, or are unable to interact digitally at all.


### PR DESCRIPTION
Add new partials for this topic. Copied directly from current DTA-> The Standard page. Most of the bulleted lists are styled exactly the same as original pages. Looks like content could be simplified somewhat.