### PR TITLE
Add two new topic pages

### DIFF
--- a/content/starting-team/digital-capability-team/finding-people-head.md
+++ b/content/starting-team/digital-capability-team/finding-people-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Finding people who work well together
+---

--- a/content/starting-team/digital-capability-team/finding-people.md
+++ b/content/starting-team/digital-capability-team/finding-people.md
@@ -1,0 +1,14 @@
+---
+layout: text/textblock
+---
+If you are responsible for [setting up a team](../roles/) you can use recruitment exercises to assess how well people have worked in teams in the past.
+
+You should find out how well the person will work both in their role and the team. Make sure your recruitment exercises explore people’s previous experience in:
+
+-  focusing on meeting user needs
+-  collaborating closely with people from other disciplines
+-  being open to working in a new way
+
+If you don’t have the chance to recruit from outside your organisation you can adapt the same recruitment exercises to find how people in your organisation have worked in previous teams.
+
+Make sure the people you have in your team are practitioners with specific experience, rather than generalists.

--- a/content/starting-team/digital-capability-team/helping-teams-head.md
+++ b/content/starting-team/digital-capability-team/helping-teams-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Helping teams increase their digital capability
+---

--- a/content/starting-team/digital-capability-team/helping-teams.md
+++ b/content/starting-team/digital-capability-team/helping-teams.md
@@ -1,0 +1,12 @@
+---
+layout: text/textblock
+---
+Teams usually have people with different levels of experience in their discipline. They should all have some experience working as a multidisciplinary team and be open to collaborating.
+
+You should encourage the people with more experience to mentor the people who are new to this way of working. This is a good way to help people who haven’t had the chance to increase the skills in their discipline because they cannot progress beyond a certain career point in a government role.
+
+Give people who have skills and expertise in a particular area the chance work in a multidisciplinary team and often they will flourish.
+
+There may be other people in your organisation who may not be as experienced but who are keen to learn and collaborate. Be open to pairing people who have less experience with experienced people from in and outside of government.
+
+Sometimes it’s possible to use secondments to temporarily transfer people who are keen to collaborate from other parts of government to fill gaps in the team.

--- a/content/starting-team/digital-capability-team/high-capability-head.md
+++ b/content/starting-team/digital-capability-team/high-capability-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Teams with high digital capability
+---

--- a/content/starting-team/digital-capability-team/high-capability.md
+++ b/content/starting-team/digital-capability-team/high-capability.md
@@ -1,0 +1,10 @@
+---
+layout: text/textblock
+---
+Teams that are digitally mature deliver quality products that meet user needs. They deliver faster and iterate quickly based on research with users.
+
+All people in the team will be experts at collaborating with people in all disciplines with different levels of experience. They know how to use modern tools and techniques.
+
+Members of these teams are excited and motivated to be working on services that help users.
+
+Even teams with a high digital capability will always be learning.

--- a/content/starting-team/digital-capability-team/how-deliver-head.md
+++ b/content/starting-team/digital-capability-team/how-deliver-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Digital capability is about how the team delivers together
+---

--- a/content/starting-team/digital-capability-team/how-deliver.md
+++ b/content/starting-team/digital-capability-team/how-deliver.md
@@ -1,0 +1,21 @@
+---
+layout: text/textblock
+---
+Often teams will have people of different levels of experience, but their individual experience is not a clear measure of the team’s digital capability.
+
+A team with people who have a low levels of experience may have high digital capability because they are:
+
+-  passionate about meeting user needs
+-  led by a very experienced product manager
+-  open to collaborating
+-  keen to work as a [multidisciplinary team](../multidisciplinary-team/)
+-  innovative
+-  not afraid to take risks.
+
+A team of experienced people may have low digital capability because they:
+
+-  don’t collaborate well with each other
+-  don’t focus on meeting user needs
+-  work in silos
+-  do things the way things have always been done
+-  are risk averse.

--- a/content/starting-team/digital-capability-team/index.yml
+++ b/content/starting-team/digital-capability-team/index.yml
@@ -7,8 +7,18 @@ header:
   - /_shared/globalheader.md
   - /_shared/header.md
 main:
-  - cards.md
-  - cards-category.md
+  - intro.md
+  - toc.md
+  - meeting-standard-head.md
+  - meeting-standard.md
+  - how-deliver-head.md
+  - how-deliver.md
+  - finding-people-head.md
+  - finding-people.md
+  - high-capability-head.md
+  - high-capability.md
+  - helping-teams-head.md
+  - helping-teams.md
   - /_shared/feedback.md
 footer:
   - /_shared/footer-gds.md

--- a/content/starting-team/digital-capability-team/intro.md
+++ b/content/starting-team/digital-capability-team/intro.md
@@ -1,0 +1,12 @@
+---
+layout: intros/intro
+category: Starting and managing a team
+title: Digital capability of the team
+subtitle: The team needs to have a high level of digital capability to build services that meet the needs of users.
+---
+
+A team with high digital capability can move quickly towards a minimum viable product (MVP). This means they can work faster with lower budgets to deliver services that are simple, clear and fast.
+
+Every service a team works on together will increase the team’s digital capability. It will also increase the ability of each person in the team to work together.
+
+Where possible, the team should be consistent from Discovery through to the when the service goes live, and beyond.

--- a/content/starting-team/digital-capability-team/meeting-standard-head.md
+++ b/content/starting-team/digital-capability-team/meeting-standard-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Meeting the Digital Service Standard
+---

--- a/content/starting-team/digital-capability-team/meeting-standard.md
+++ b/content/starting-team/digital-capability-team/meeting-standard.md
@@ -1,0 +1,8 @@
+---
+layout: text/textblock
+---
+Your team must have a high level of digital capability or be working to increase it to meet [Criteria 2: Have a multidisciplinary team](https://www.dta.gov.au/standard/2-multidisciplinary-team/) of the [Digital Service Standard](https://www.dta.gov.au/standard/).
+
+In your assessments you will need to explain how these roles have been filled.
+
+The Digital Service Standard guides teams to build services that are simpler, clearer and faster.

--- a/content/starting-team/digital-capability-team/toc.md
+++ b/content/starting-team/digital-capability-team/toc.md
@@ -1,0 +1,10 @@
+---
+layout: nav/sections
+title: Contents
+sections:
+  - Meeting the Digital Service Standard
+  - Digital capability is about how the team delivers together
+  - Finding people who work well together
+  - Teams with high digital capability
+  - Helping teams increase their digital capability
+---

--- a/content/starting-team/roles/cstudies-head.md
+++ b/content/starting-team/roles/cstudies-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Case studies and examples
+---

--- a/content/starting-team/roles/cstudies.md
+++ b/content/starting-team/roles/cstudies.md
@@ -1,0 +1,9 @@
+---
+layout: cards/cards
+cards:
+  - image: starting-team/yiannis-delivery-manager.jpg
+    headline: So what does a delivery manager do?
+    text: Delivery managers play a key role at the Digital Transformation Agency.  If you’re new to digital transformation, you might not have come across this role before.
+    link: 'https://www.dta.gov.au/blog/so-what-does-a-delivery-manager-do/'
+    cta: Read on DTA blog
+---

--- a/content/starting-team/roles/each-role-head.md
+++ b/content/starting-team/roles/each-role-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: What each role does
+---

--- a/content/starting-team/roles/each-role.md
+++ b/content/starting-team/roles/each-role.md
@@ -1,0 +1,94 @@
+---
+layout: text/textblock
+---
+You need each of these roles in your multidisciplinary team.
+#### Product manager
+The product manager leads strategic direction and product delivery. They:
+
+-  work with the user researcher and service designer to understand the current state of the product
+-  work with the team to set the vision for improving the product
+-  work with the user researcher, service designer and delivery manager to make sure the product meets user needs
+-  own the product backlog and manage execution
+-  prioritise user stories
+-  accept user stories when they’re delivered
+-  manage approvals
+-  manage the budget
+-  ensure the right team culture develops
+-  are on hand to answer questions from the team
+-  facilitate travel
+
+#### Service manager
+The service manager owns and is responsible for the whole user experience of the digital service. They are:
+
+-  a senior executive with the capacity to unblock obstacles, present and champion the service at the most senior levels of the Australian Public Service
+-  experienced leaders with a strong understanding of their service and its users
+-  able to to ensure the service is delivered successfully and meets the needs of the users
+-  able to assist in making sure internal processes are focussed on achieving results for the service
+-  available to the team, but not necessarily present with them at all times
+
+#### Delivery manager
+The delivery manager enables the team to deliver high-quality services. They remove blockers to progress and run product meetings. They:
+
+-  deliver products and services using agile methodologies, iterating products and processes frequently to meet users’ needs
+-  work with product managers to plan the work needed to deliver products and services
+-  run the daily stand up and weekly team meetings
+-  make sure that the backlog and team artefacts are up to date
+-  manage the budget with the product manager
+
+Find out more about [what a delivery manager does](https://www.dta.gov.au/blog/so-what-does-a-delivery-manager-do/) on the Digital Transformation Agency blog.
+
+#### User researcher
+The user researcher helps the team develop a deep understanding of users and their needs. They:
+
+-  work closely with the product manager and designers to ensure prioritisation of the work to meet the needs of the users
+-  are responsible for building understanding of the users and their behaviour, and providing insight to the team about how users interact with products and services
+-  take the lead on running sessions with real users, and communicating findings back to the whole team, creating actionable insights to guide work
+
+#### Designers
+Designers help your team create user-focused services and a consistent user experience.
+
+Depending on the type of service you’re building, you may need a team of designers with a range of different skills (for example, in interaction or user experience design).
+
+##### Service designer
+The service designer works from the user research to identify how a service could be delivered so that it better meets user needs. They:
+
+-  design user-focused services that meet web standards for all users, channels and touchpoints
+-  create a blueprint or map of the proposed service to make sure the key parts are built in from the start
+-  help the team in the development and continual iteration of services, making sure that there are consistent user experiences
+
+##### Content designer
+The content designer makes sure that the content in the service meets user needs. They are focused on written content, but also work on the visual and interactive parts of products. They:
+
+-  develop content plans and strategies based on user needs
+-  write clear, usable content in plain English
+-  review content to make sure it’s accurate, relevant and written in line with the [GOV.AU Content Guide](https://guides.service.gov.au/content-guide/)
+-  communicate the principles of content design to your service team and others across your organisation
+-  advocate for users of the service by challenging requests that don’t support their needs
+
+##### Interaction designer
+The interaction designer is responsible for designing a user-focused and accessible service, and making use of established design patterns. They:
+
+-  create the user interface for the service, ensuring that it is designed to work across devices and browsers
+-  make sure the interface meets web standards, is accessible and able to be used by people regardless of their digital literacy
+-  make use of agreed design patterns and contribute to the design community to improve and add to design patterns
+- either make prototypes in HTML or have enough familiarity with code to work closely with developers to make the HTML prototypes
+
+Interaction designers work closely with other members of the team:
+ - content designer — to improve the usability of the service
+ -  user researcher — to conduct usability testing and design experiments
+ -  technical team members — to develop and iterate prototypes to help improve the service
+
+#### Developer
+The developer designs quality, well-tested software and sites according to standards and best practice. They:
+
+-  build software with a focus on what users need from your service and how they’ll use it
+-  write quality well-tested code and try to find the simplest solution to a given problem
+-  keep security, accessibility and open standards in mind
+-  improve (refactor) the technical implementation as they go along
+-  solve technical problems
+
+Your team might have a mixture of developers that specialise in being front-end or back-end developers, but most will have solid skills in both areas.
+
+Some developers may need mentoring in user-centred design. If you involve them from the Discovery stage, it will help them to build empathy with users. They’ll also gain experience in user research and bring their expertise to the insights gained.
+
+Sometimes the team will need a technical lead to make it easier to prioritise work. This person is still part of the team and collaborates with everyone to make decisions.

--- a/content/starting-team/roles/index.yml
+++ b/content/starting-team/roles/index.yml
@@ -7,8 +7,22 @@ header:
   - /_shared/globalheader.md
   - /_shared/header.md
 main:
-  - cards.md
-  - cards-category.md
+  - intro.md
+  - toc.md
+  - meeting-standard-head.md
+  - meeting-standard.md
+  - roles-needs-head.md
+  - roles-needs.md
+  - self-organise-head.md
+  - self-organise.md
+  - levels-experience-head.md
+  - levels-experience.md
+  - each-role-head.md
+  - each-role.md
+  - some-for-part-head.md
+  - some-for-part.md
+  - cstudies-head.md
+  - cstudies.md
   - /_shared/feedback.md
 footer:
   - /_shared/footer-gds.md

--- a/content/starting-team/roles/intro.md
+++ b/content/starting-team/roles/intro.md
@@ -1,6 +1,6 @@
 ---
 layout: intros/intro
-category: Starting a team
+category: Starting and managing a team
 title: Roles
 subtitle: Team capabilities are key to building and maintaining a user-centred service. You need team members with a range of skills and who are open to collaborating.
 ---

--- a/content/starting-team/roles/intro.md
+++ b/content/starting-team/roles/intro.md
@@ -1,0 +1,16 @@
+---
+layout: intros/intro
+category: Starting a team
+title: Roles
+subtitle: Team capabilities are key to building and maintaining a user-centred service. You need team members with a range of skills and who are open to collaborating.
+---
+
+To build the right thing in the best way, the service team must include specialists in specific  roles. As a team they provide you with capabilities in research, design and delivery. This is called a [multidisciplinary team](../multidisciplinary-team/).
+
+You may need to include other roles, skills or capability depending on the size of the service and where it is the [service design and delivery process](../../service-design-delivery-process/). It’s ideal to have the same people in the same roles through the whole process, but the team needs to be flexible and adjust to fit the work.
+
+
+If you are responsible for [recruiting for a team](../recruiting-team/) you should understand:
+-  what each role does
+-  the concept of a [multidisciplinary team and T-shaped skills](../multidisciplinary-team/)
+-  how to build team culture.

--- a/content/starting-team/roles/levels-experience-head.md
+++ b/content/starting-team/roles/levels-experience-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: People can have different levels of experience in their roles
+---

--- a/content/starting-team/roles/levels-experience.md
+++ b/content/starting-team/roles/levels-experience.md
@@ -1,0 +1,13 @@
+---
+layout: text/textblock
+quote: Multidisciplinary teams are a great way for people to increase their skills.
+---
+It’s important that each team member is a practitioner in their role (for example, interaction design or user research). They should also have some knowledge about other related roles.
+
+People who have both expertise in their role and the ability to collaborate across others are said to have [T-shaped skills](../multidisciplinary-team).
+
+It’s fine if a team member is still building experience in their role, but they do need a depth of knowledge about the area in which they’re working. A person with generalist skills usually won’t be able to deliver what the team needs.
+
+It can help to pair up people in the same role, so the person with more experience can mentor the other.
+
+Some of the key traits that help people succeed on multidisciplinary teams are openness to trying new things and willingness to ask for help.

--- a/content/starting-team/roles/meeting-standard-head.md
+++ b/content/starting-team/roles/meeting-standard-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Meeting the Digital Service Standard
+---

--- a/content/starting-team/roles/meeting-standard.md
+++ b/content/starting-team/roles/meeting-standard.md
@@ -1,0 +1,8 @@
+---
+layout: text/textblock
+---
+You must form and maintain a multidisciplinary team to meet [Criteria 2: Have a multidisciplinary team](https://www.dta.gov.au/standard/2-multidisciplinary-team/) of the [Digital Service Standard](https://www.dta.gov.au/standard/).
+
+In your assessments you will need to explain how these roles have been filled.
+
+The Digital Service Standard guides teams to build services that are simpler, clearer and faster.

--- a/content/starting-team/roles/roles-needs-head.md
+++ b/content/starting-team/roles/roles-needs-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Roles your team needs
+---

--- a/content/starting-team/roles/roles-needs.md
+++ b/content/starting-team/roles/roles-needs.md
@@ -1,0 +1,13 @@
+---
+layout: text/textblock
+---
+A team building a government service needs to have people with the following roles, either in the team or available to it:
+
+-  service manager
+-  product manager
+-  delivery manager
+-  user researcher
+-  designers (content designer, service designer and interaction designer)
+-  developer.
+
+You may not need all roles in all stages of the [service design and delivery process](../../service-design-delivery-process/). Sometimes you may need additional capacity in some stages of the process (for example, you may bring in subject matter experts in Alpha stage.)

--- a/content/starting-team/roles/self-organise-head.md
+++ b/content/starting-team/roles/self-organise-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: The team self-organises
+---

--- a/content/starting-team/roles/self-organise.md
+++ b/content/starting-team/roles/self-organise.md
@@ -1,0 +1,8 @@
+---
+layout: text/textblock
+---
+Some of the people in a multidisciplinary team will focus more on managing the team’s activities (for example, the product manager and delivery manager). These people are still part of the team and collaborate with the others to work out the right thing for the team to do next.
+
+Your whole team, and in particular your designers, user researchers, content designers and developers, must work together to design, build and iterate a service based on the [user needs](../../user-research/identifying-users-needs/) of the people your service is aimed at.
+
+Everyone who is in your team should be open to collaborating and understand what a [multidisciplinary team](../multidisciplinary-team) looks like.

--- a/content/starting-team/roles/some-for-part-head.md
+++ b/content/starting-team/roles/some-for-part-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: You may need some roles for only part of the process
+---

--- a/content/starting-team/roles/some-for-part.md
+++ b/content/starting-team/roles/some-for-part.md
@@ -1,0 +1,14 @@
+---
+layout: text/textblock
+---
+There are some roles with specific skills or capabilities that the team will only need for part of the [service design and delivery process](../../service-design-delivery-process/):
+
+-  subject matter experts
+-  architect
+-  business analyst
+-  web operations engineer
+-  support operations staff
+-  ethical hacker
+-  performance analyst
+-  IT security specialists
+-  procurement and contract managers.

--- a/content/starting-team/roles/toc.md
+++ b/content/starting-team/roles/toc.md
@@ -1,0 +1,12 @@
+---
+layout: nav/sections
+title: Contents
+sections:
+  - Meeting the Digital Service Standard
+  - Roles your team needs
+  - The team self-organises
+  - People can have different levels of experience in their roles
+  - What each role does
+  - You may need some roles for only part of the process
+  - Case studies and examples
+---


### PR DESCRIPTION
Add content for new topics, 'Roles' and 'Digital capability of the team' within the 'Starting and managing a team' category for Guides. Content reflects documentation ready by noon Mon 7 Aug.