### PR TITLE
Remove rogue full-stops, updated breadcrumb label

### DIFF
--- a/content/starting-team/digital-capability-team/how-deliver.md
+++ b/content/starting-team/digital-capability-team/how-deliver.md
@@ -10,7 +10,7 @@ A team with people who have a low levels of experience may have high digital cap
 -  open to collaborating
 -  keen to work as a [multidisciplinary team](../multidisciplinary-team/)
 -  innovative
--  not afraid to take risks.
+-  not afraid to take risks
 
 A team of experienced people may have low digital capability because they:
 
@@ -18,4 +18,4 @@ A team of experienced people may have low digital capability because they:
 -  don’t focus on meeting user needs
 -  work in silos
 -  do things the way things have always been done
--  are risk averse.
+-  are risk averse

--- a/content/starting-team/dss.md
+++ b/content/starting-team/dss.md
@@ -5,6 +5,6 @@ dss:
 section: Why
 ---
 ### Meeting the Digital Service Standard
-You must form and maintain a multidisciplinary team to meet *Criteria 2: Have a multidisciplinary team* of the Digital Service Standard.
+You must form and maintain a multidisciplinary team to meet **Criteria 2: Have a multidisciplinary team** of the Digital Service Standard.
 
 The Digital Service Standard guides teams to build services that are simpler, clearer and faster.

--- a/content/starting-team/index.yml
+++ b/content/starting-team/index.yml
@@ -1,4 +1,4 @@
-title: Starting and managing a team
+title: Starting a team
 weight: 30
 hidden: true
 theme: blue

--- a/content/starting-team/roles/intro.md
+++ b/content/starting-team/roles/intro.md
@@ -10,7 +10,7 @@ To build the right thing in the best way, the service team must include speciali
 You may need to include other roles, skills or capability depending on the size of the service and where it is the [service design and delivery process](../../service-design-delivery-process/). It’s ideal to have the same people in the same roles through the whole process, but the team needs to be flexible and adjust to fit the work.
 
 
-If you are responsible for [recruiting for a team](../recruiting-team/) you should understand:
+If you are responsible for recruiting for a team you should understand:
 -  what each role does
 -  the concept of a [multidisciplinary team and T-shaped skills](../multidisciplinary-team/)
--  how to build team culture.
+-  how to build team culture

--- a/content/starting-team/roles/roles-needs.md
+++ b/content/starting-team/roles/roles-needs.md
@@ -8,6 +8,6 @@ A team building a government service needs to have people with the following rol
 -  delivery manager
 -  user researcher
 -  designers (content designer, service designer and interaction designer)
--  developer.
+-  developer
 
 You may not need all roles in all stages of the [service design and delivery process](../../service-design-delivery-process/). Sometimes you may need additional capacity in some stages of the process (for example, you may bring in subject matter experts in Alpha stage.)

--- a/content/starting-team/roles/some-for-part.md
+++ b/content/starting-team/roles/some-for-part.md
@@ -11,4 +11,4 @@ There are some roles with specific skills or capabilities that the team will onl
 -  ethical hacker
 -  performance analyst
 -  IT security specialists
--  procurement and contract managers.
+-  procurement and contract managers


### PR DESCRIPTION
- Removed full stops from bulleted lists where they were incorrectly applied to fragments
- Updated title in yml for ‘Starting a team’ page to reflect new name and appear correctly in breadcrumbs for related topics
- Applied correct bold style to text in the DSS block on ‘Starting a team’ page