### PR TITLE
Adds `Scope of the Standard` content

### DIFF
--- a/content/standard/scope-standard/index.yml
+++ b/content/standard/scope-standard/index.yml
@@ -1,0 +1,18 @@
+title: Scope of the Digital Service Standard
+weight: 20
+layout: layout/topic
+theme: blue
+header:
+  - /_shared/globalheader.md
+  - /_shared/header.md
+main:
+  - intro.md
+  - transactional-head.md
+  - transactional.md
+  - information-head.md
+  - information.md
+  - not-apply-head.md
+  - not-apply.md
+  - /_shared/feedback.md
+footer:
+  - /_shared/footer-gds.md

--- a/content/standard/scope-standard/index.yml
+++ b/content/standard/scope-standard/index.yml
@@ -7,6 +7,7 @@ header:
   - /_shared/header.md
 main:
   - intro.md
+  - toc.md
   - transactional-head.md
   - transactional.md
   - information-head.md

--- a/content/standard/scope-standard/information-head.md
+++ b/content/standard/scope-standard/information-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Information services
+---

--- a/content/standard/scope-standard/information.md
+++ b/content/standard/scope-standard/information.md
@@ -1,0 +1,13 @@
+---
+layout: text/textblock
+---
+
+An information service helps users to better understand and interact with government. These services are typically websites or mobile applications that provide information (such as reports, fact sheets and video) to the public.
+
+Examples of information services:
+
+*	agency website
+*	smart answers / virtual assistants
+*	e-learning
+*	publications
+*	multimedia

--- a/content/standard/scope-standard/intro.md
+++ b/content/standard/scope-standard/intro.md
@@ -1,0 +1,13 @@
+---
+layout: intros/intro
+category: Digital Service Standard
+---
+
+The [Digital Service Standard](../standard/) (the Standard) applies to public facing Australian Government (federal) services owned by [non-corporate Commonwealth entities](http://www.finance.gov.au/resource-management/governance/#flipchart).
+
+The Standard applies to:
+
+* new and redesigned government services, [information](#information-services) and [transactional](#transactional-services)
+* all [high volume transactional services](#transactional-services) (for example, lodging a tax return online), existing or being designed/redesigned
+
+Proposed work on new and redesigned services will be affected by the [moratorium on investment in Australian Government service delivery](https://www.dta.gov.au/standard/moratorium/).

--- a/content/standard/scope-standard/not-apply-head.md
+++ b/content/standard/scope-standard/not-apply-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: The Standard does not apply to everything
+---

--- a/content/standard/scope-standard/not-apply.md
+++ b/content/standard/scope-standard/not-apply.md
@@ -1,0 +1,9 @@
+---
+layout: text/textblock
+---
+
+The Standard does not apply to state, territory or local government services. However, these jurisdictions may decide to apply the Standard to improve their service delivery.
+
+Personal ministerial websites (that contain material on a minister’s party political activities or views on issues not related to their ministerial role) are not included in the scope of the Standard.
+
+Full or partial exemptions from the Standard may be appropriate in certain cases — contact us for advice: [standard@digital.gov.au](mailto:standard@digital.gov.au?subject=Scope%20of%20the%20Standard)

--- a/content/standard/scope-standard/toc.md
+++ b/content/standard/scope-standard/toc.md
@@ -1,0 +1,8 @@
+---
+layout: nav/sections
+title: Contents
+sections:
+  - Transactional services
+  - Information services
+  - The Standard does not apply to everything
+---

--- a/content/standard/scope-standard/transactional-head.md
+++ b/content/standard/scope-standard/transactional-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Transactional services
+---

--- a/content/standard/scope-standard/transactional.md
+++ b/content/standard/scope-standard/transactional.md
@@ -1,0 +1,14 @@
+---
+layout: text/textblock
+---
+
+Transactional services are defined as any service where the transaction results in a change to the records held by government. A transactional service typically involves an exchange of information, money, licences, goods.
+
+Examples of transactional services:
+
+*	submitting a claim
+*	registering for a business
+*	updating contact details
+*	lodging a tax return
+
+**High volume transactional services** are defined as processing (or likely to process) more than 50,000 transactions every year.


### PR DESCRIPTION
I’ll change the `moratorium` link once that content is added to Guides.