### PR TITLE
Addcontent/moratorium

### DIFF
--- a/content/standard/moratorium/exemptions-head.md
+++ b/content/standard/moratorium/exemptions-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Exemptions
+---

--- a/content/standard/moratorium/exemptions.md
+++ b/content/standard/moratorium/exemptions.md
@@ -9,7 +9,7 @@ Some service delivery investments are exempt from the moratorium.
  - the investment has been agreed by the Cabinet or the Prime Minister
  - it is an information or transactional service and the service team can demonstrate they are applying the [Digital Service Standard](/standard/); for example, an assessment team is in place and the service is reporting its progress on the dashboard
  - emergency or critical unforeseen events require the investment (for example, natural disasters)
- - funding for the investment was provided before or through the 2015-16 Budget process.
+ - funding for the investment was provided before or through the 2015-16 Budget process
 
 You need to notify your agency’s Digital Transformation Coordinator if your service is automatically exempt. The Digital Transformation Coordinator must then advise the Digital Transformation Agency. The Digital Transformation Agency will confirm whether an automatic exemption applies.
 
@@ -21,12 +21,12 @@ Some investments that **may be granted exemption** include:
  - establishing a mobile or temporary shopfront
  - service delivery capability outside Australia (such as a visa office)
  - delivering a service jointly with state and territory entities
- - where there will be significant user benefit that cannot happen through an existing service delivery channel.
+ - where there will be significant user benefit that cannot happen through an existing service delivery channel
 
 You will **not** be granted an exemption if your investment will:
 
  - duplicate existing Australian Government capabilities
  - fragment users’ experience
- - reduce government efficiency.
+ - reduce government efficiency
 
 If your investment is not exempt, the Digital Transformation Agency will work with you to find a better way to meet your users’ needs.

--- a/content/standard/moratorium/exemptions.md
+++ b/content/standard/moratorium/exemptions.md
@@ -1,0 +1,32 @@
+---
+layout: text/textblock
+---
+
+Some service delivery investments are exempt from the moratorium.
+
+<a name="automatic-exemption"></a>Your investment is **automatically exempt** if:
+
+ - the investment has been agreed by the Cabinet or the Prime Minister
+ - it is an information or transactional service and the service team can demonstrate they are applying the [Digital Service Standard](/standard/); for example, an assessment team is in place and the service is reporting its progress on the dashboard
+ - emergency or critical unforeseen events require the investment (for example, natural disasters)
+ - funding for the investment was provided before or through the 2015-16 Budget process.
+
+You need to notify your agency’s Digital Transformation Coordinator if your service is automatically exempt. The Digital Transformation Coordinator must then advise the Digital Transformation Agency. The Digital Transformation Agency will confirm whether an automatic exemption applies.
+
+You can also **apply for an exemption**. You should contact the Digital Transformation Agency ([moratorium@digital.gov.au](mailto:moratorium@digital.gov.au)) to work with your agency. Your minister can then write to the Assistant Minister for Cities and Digital Transformation to request exemption.
+
+Some investments that **may be granted exemption** include:
+
+ - moving an existing face-to-face presence without expanding the existing footprint
+ - establishing a mobile or temporary shopfront
+ - service delivery capability outside Australia (such as a visa office)
+ - delivering a service jointly with state and territory entities
+ - where there will be significant user benefit that cannot happen through an existing service delivery channel.
+
+You will **not** be granted an exemption if your investment will:
+
+ - duplicate existing Australian Government capabilities
+ - fragment users’ experience
+ - reduce government efficiency.
+
+If your investment is not exempt, the Digital Transformation Agency will work with you to find a better way to meet your users’ needs.

--- a/content/standard/moratorium/index.yml
+++ b/content/standard/moratorium/index.yml
@@ -1,0 +1,16 @@
+title: Digital Service Standard
+weight: 20
+layout: layout/topic
+theme: blue
+header:
+  - /_shared/globalheader.md
+  - /_shared/header.md
+main:
+  - intro.md
+  - scope-head.md
+  - scope.md
+  - exemptions-head.md
+  - exemptions.md
+  - /_shared/feedback.md
+footer:
+  - /_shared/footer.md

--- a/content/standard/moratorium/index.yml
+++ b/content/standard/moratorium/index.yml
@@ -1,4 +1,4 @@
-title: Digital Service Standard
+title: Moratorium on service investment
 weight: 20
 layout: layout/topic
 theme: blue
@@ -7,6 +7,7 @@ header:
   - /_shared/header.md
 main:
   - intro.md
+  - toc.md
   - scope-head.md
   - scope.md
   - exemptions-head.md

--- a/content/standard/moratorium/intro.md
+++ b/content/standard/moratorium/intro.md
@@ -1,0 +1,8 @@
+---
+layout: intros/intro
+category: Digital Service Standard
+---
+
+The Australian Government has established a moratorium that stops Commonwealth (federal) agencies from investing in new, or duplicating, service delivery capability. The moratorium is an important tool to help government limit the fragmenting of users’ experience across the Australian Government.
+
+If you are the project owner for a service delivery product, it is your responsibility to assess whether the moratorium applies to your proposed investment. You can talk to your Digital Transformation Coordinator or the Digital Transformation Agency ([moratorium@digital.gov.au](mailto:moratorium@digital.gov.au)) for help with this.

--- a/content/standard/moratorium/scope-head.md
+++ b/content/standard/moratorium/scope-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Scope
+---

--- a/content/standard/moratorium/scope.md
+++ b/content/standard/moratorium/scope.md
@@ -2,11 +2,11 @@
 layout: text/textblock
 ---
 
-The moratorium applies to investments in service delivery capability made by Australian Government non-corporate Commonwealth entities under *[section 11(b) of the Public Governance, Performance and Accountability Act 2013](https://www.legislation.gov.au/Details/C2016C00414/Html/Text#_Toc450312934)*.
+The moratorium applies to investments in service delivery capability made by Australian Government non-corporate Commonwealth entities under [section 11(b) of the Public Governance, Performance and Accountability Act 2013](https://www.legislation.gov.au/Details/C2016C00414/Html/Text#_Toc450312934).
 
 The moratorium does not apply to services owned by state, territory or local governments.
 
-Information and transactional services [within the scope of the Digital Service Standard](/standard/scope-of-standard/) (the Standard) are covered by the moratorium. However, if you can demonstrate that you are working to meet, or have met, the Standard you will receive an [automatic exemption](#automatic-exemption).
+Information and transactional services [within the scope of the Digital Service Standard](../scope-standard/) (the Standard) are covered by the moratorium. However, if you can demonstrate that you are working to meet, or have met, the Standard you will receive an [automatic exemption](#automatic-exemption).
 
 Unless you have an exemption, you **cannot** make new investments in:
 
@@ -15,10 +15,10 @@ Unless you have an exemption, you **cannot** make new investments in:
  - digital platforms, such as digital identity, voice authentication, and tell us once functionality
  - face-to-face service delivery capabilities, such as establishing new shopfronts
  - telephony service delivery capabilities, such as establishing new service centres and new telephony contracts
- - grant management ICT systems and administration capabilities, including outsourcing grant management processes and enhancing existing grant management processes.
+ - grant management ICT systems and administration capabilities, including outsourcing grant management processes and enhancing existing grant management processes
 
 You **can** invest in:
 
  - maintaining existing digital services, such as minor upgrades and maintenance
  - shopfront renewals and consolidations
- - extensions of existing contracts to telephony services.
+ - extensions of existing contracts to telephony services

--- a/content/standard/moratorium/scope.md
+++ b/content/standard/moratorium/scope.md
@@ -1,0 +1,24 @@
+---
+layout: text/textblock
+---
+
+The moratorium applies to investments in service delivery capability made by Australian Government non-corporate Commonwealth entities under *[section 11(b) of the Public Governance, Performance and Accountability Act 2013](https://www.legislation.gov.au/Details/C2016C00414/Html/Text#_Toc450312934)*.
+
+The moratorium does not apply to services owned by state, territory or local governments.
+
+Information and transactional services [within the scope of the Digital Service Standard](/standard/scope-of-standard/) (the Standard) are covered by the moratorium. However, if you can demonstrate that you are working to meet, or have met, the Standard you will receive an [automatic exemption](#automatic-exemption).
+
+Unless you have an exemption, you **cannot** make new investments in:
+
+ - information services, such as new websites
+ - transactional services
+ - digital platforms, such as digital identity, voice authentication, and tell us once functionality
+ - face-to-face service delivery capabilities, such as establishing new shopfronts
+ - telephony service delivery capabilities, such as establishing new service centres and new telephony contracts
+ - grant management ICT systems and administration capabilities, including outsourcing grant management processes and enhancing existing grant management processes.
+
+You **can** invest in:
+
+ - maintaining existing digital services, such as minor upgrades and maintenance
+ - shopfront renewals and consolidations
+ - extensions of existing contracts to telephony services.

--- a/content/standard/moratorium/toc.md
+++ b/content/standard/moratorium/toc.md
@@ -1,0 +1,7 @@
+---
+layout: nav/sections
+title: Contents
+sections:
+  - Scope
+  - Exemptions
+---


### PR DESCRIPTION
Need to link to this from the `Scope of the Standard` content once that is live.

Also probably from the Standard page itself.