### PR TITLE
Add ‘Understand the content lifecycle’ topic

### DIFF
--- a/content/governing-content/index.yml
+++ b/content/governing-content/index.yml
@@ -1,0 +1,11 @@
+title: Governing content
+weight: 70
+theme: blue
+header:
+  - /_shared/globalheader.md
+  - header.md
+main:
+
+  - /_shared/feedback.md
+footer:
+  - /_shared/footer.md

--- a/content/governing-content/understand-content-lifecycle/ensure-head.md
+++ b/content/governing-content/understand-content-lifecycle/ensure-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: How to ensure content usability
+---

--- a/content/governing-content/understand-content-lifecycle/index.yml
+++ b/content/governing-content/understand-content-lifecycle/index.yml
@@ -1,0 +1,15 @@
+title: Understand the content lifecycle
+weight: 10
+theme: blue
+header:
+  - /_shared/globalheader.md
+  - /_shared/header.md
+main:
+  - intro.md
+  - stages-head.md
+  - stages.md
+  - ensure-head.md
+  - stages-cards.md
+  - /_shared/feedback.md
+footer:
+  - /_shared/footer.md

--- a/content/governing-content/understand-content-lifecycle/intro.md
+++ b/content/governing-content/understand-content-lifecycle/intro.md
@@ -1,0 +1,16 @@
+---
+layout: intros/intro_with_nav
+subtitle: Understand the content lifecycle - know how to create, test and improve content
+metaTitle1: Created by
+metaValue1: Digital Transformation Agency and the Attorney-General's Department
+category: Governing content
+---
+
+Know how to use the stages of the content lifecycle to create, test and improve your content’s usability.
+
+## [3]Why use the content lifecycle?  
+Getting content published and keeping it relevant involves a continuous focus on value for the user.
+
+Content requests often need to be published in a rush, resulting in a tendency to shortcut on quality checks.
+
+Content skills need to be applied at every stage in the process to help work out a channel and audience approach.

--- a/content/governing-content/understand-content-lifecycle/stages-cards.md
+++ b/content/governing-content/understand-content-lifecycle/stages-cards.md
@@ -1,0 +1,19 @@
+---
+layout: cards/cards
+cards:
+  - headline: Planning content
+    text: Plan to define the end-to-end content task so the broader team has clarity about user needs and business goals.
+    link: 'planning-content'
+  - headline: Creating content
+    text: Start the process of creating content by guiding authors in how to write for plain English and web standards.
+    link: 'creating-content'
+  - headline: Checking and testing content
+    text: Involve the right people and expertise to check and test content quality before revising and final sign off.
+    link: 'checking-testing-content'
+  - headline: Signing off content
+    text: Create a brief or checklist for final sign off, so the approver knows what they need to do.
+    link: 'signing-off-content'
+  - headline: Publishing content
+    text: Prepare and check that quality content is uploaded into your CMS platform and publish it live.
+    link: 'publishing-content'
+---

--- a/content/governing-content/understand-content-lifecycle/stages-head.md
+++ b/content/governing-content/understand-content-lifecycle/stages-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Content lifecycle stages
+---

--- a/content/governing-content/understand-content-lifecycle/stages.md
+++ b/content/governing-content/understand-content-lifecycle/stages.md
@@ -1,0 +1,9 @@
+---
+layout: text/textblock
+section: Content lifecycle stages
+---
+- Planning content
+- Creating content
+- Checking and testing content
+- Signing off content
+- Publishing content


### PR DESCRIPTION
Add stub ‘Governing content’ category to sit over this topic
Add topic, incl. links to future sub-topic pages

Submitting this commit early so that other teammates can publish other topics around this.