### PR TITLE
Add 2 subtopics for 'Understand the content lifecycle`

### DIFF
--- a/content/governing-content/understand-content-lifecycle/checking-testing-content/index.yml
+++ b/content/governing-content/understand-content-lifecycle/checking-testing-content/index.yml
@@ -1,0 +1,20 @@
+title: Checking and testing content
+weight: 30
+theme: blue
+header:
+  - /_shared/globalheader.md
+  - /_shared/header.md
+main:
+  - intro.md
+  - sections.md
+  - templates-head.md
+  - templates.md
+  - workflow-head.md
+  - workflow.md
+  - skills-head.md
+  - skills.md
+  - typical-tasks-head.md
+  - typical-tasks.md
+  - /_shared/feedback.md
+footer:
+  - /_shared/footer.md

--- a/content/governing-content/understand-content-lifecycle/checking-testing-content/intro.md
+++ b/content/governing-content/understand-content-lifecycle/checking-testing-content/intro.md
@@ -1,0 +1,9 @@
+---
+layout: intros/intro_with_nav
+subtitle: Involve the right people and expertise to check and test content quality, and revise before sending for final sign off.
+category: Governing content
+---
+## [3]Why check and test content?  
+- Checking before sign off prevents prevents double-handling of content.
+- Testing ensures content is user-focused.
+- Checks avoid the buildup of published content that needs to be repurposed for usability.

--- a/content/governing-content/understand-content-lifecycle/checking-testing-content/sections.md
+++ b/content/governing-content/understand-content-lifecycle/checking-testing-content/sections.md
@@ -1,0 +1,8 @@
+---
+layout: nav/sections
+sections:
+  - Tools and templates
+  - Workflow process
+  - Skills
+  - Typical tasks
+---

--- a/content/governing-content/understand-content-lifecycle/checking-testing-content/skills-head.md
+++ b/content/governing-content/understand-content-lifecycle/checking-testing-content/skills-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Skills
+---

--- a/content/governing-content/understand-content-lifecycle/checking-testing-content/skills.md
+++ b/content/governing-content/understand-content-lifecycle/checking-testing-content/skills.md
@@ -1,0 +1,18 @@
+---
+layout: text/textblock
+section: Skills
+---
+Identify the skills needed to check and test for business and user needs.
+
+## [2]Product lead, subject matter expert
+- business objectives
+- legislation requirements
+
+## [2]Communications lead
+- messaging across channels
+
+## [2]Communications writer, web writer, content lead
+- user-centred language
+- SEO and metadata
+- accessibility
+- persuasion and influencing

--- a/content/governing-content/understand-content-lifecycle/checking-testing-content/templates-head.md
+++ b/content/governing-content/understand-content-lifecycle/checking-testing-content/templates-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Tools and templates
+---

--- a/content/governing-content/understand-content-lifecycle/checking-testing-content/templates.md
+++ b/content/governing-content/understand-content-lifecycle/checking-testing-content/templates.md
@@ -1,0 +1,8 @@
+---
+layout: text/textblock
+section: Tools and templates
+---
+
+- Use the [Content production template 0KB DOCX](/sitemap) for checking that content is ready for final sign off or making notes about revisions.
+
+- Use tools such as the [Hemingway app](http://www.hemingwayapp.com/) to check the readability of your content. You should aim for Grade 5 Flesch Kincaid with the content rating no higher than Grade 9.

--- a/content/governing-content/understand-content-lifecycle/checking-testing-content/typical-tasks-head.md
+++ b/content/governing-content/understand-content-lifecycle/checking-testing-content/typical-tasks-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Typical tasks
+---

--- a/content/governing-content/understand-content-lifecycle/checking-testing-content/typical-tasks.md
+++ b/content/governing-content/understand-content-lifecycle/checking-testing-content/typical-tasks.md
@@ -1,0 +1,17 @@
+---
+layout: text/textblock
+section: Typical tasks
+---
+The broader team should contribute to content checking and testing.
+
+## [2]Checks by product lead, subject matter expert
+- accuracy, currency, compliance
+
+## [2]Checks by communications lead
+- consistent agency messaging across channels
+
+## [2]Checks by communications writer, web writer, content lead
+- user-focused language and readability level
+- plain English
+- SEO and metadata
+- accessibility (content assets and additional formats)

--- a/content/governing-content/understand-content-lifecycle/checking-testing-content/workflow-head.md
+++ b/content/governing-content/understand-content-lifecycle/checking-testing-content/workflow-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Workflow process
+---

--- a/content/governing-content/understand-content-lifecycle/checking-testing-content/workflow.md
+++ b/content/governing-content/understand-content-lifecycle/checking-testing-content/workflow.md
@@ -1,0 +1,9 @@
+---
+layout: text/textblock
+section: Workflow process
+---
+Experts should use the content production template (first used in the planning and creating stages) to check off quality or make comments to revise.
+
+These checks and tests may be all the approval you need for the content to be uploaded live to the platform. This will depend on the type of content and the authority of your web team.
+
+Alternatively if the content is high profile it will need more senior clearance. Send a sign off brief once checks have been done. The brief should itemise these previous checks for approver visibility (see the next lifecycle stage).

--- a/content/governing-content/understand-content-lifecycle/index.yml
+++ b/content/governing-content/understand-content-lifecycle/index.yml
@@ -6,8 +6,6 @@ header:
   - /_shared/header.md
 main:
   - intro.md
-  - stages-head.md
-  - stages.md
   - ensure-head.md
   - stages-cards.md
   - /_shared/feedback.md

--- a/content/governing-content/understand-content-lifecycle/intro.md
+++ b/content/governing-content/understand-content-lifecycle/intro.md
@@ -3,6 +3,8 @@ layout: intros/intro_with_nav
 subtitle: Understand the content lifecycle - know how to create, test and improve content
 metaTitle1: Created by
 metaValue1: Digital Transformation Agency and the Attorney-General's Department
+metaTitle2: Reviewed on
+metaValue2: 31 October 2017
 category: Governing content
 ---
 

--- a/content/governing-content/understand-content-lifecycle/planning-content/activities-head.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/activities-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Activities
+---

--- a/content/governing-content/understand-content-lifecycle/planning-content/activities.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/activities.md
@@ -1,0 +1,15 @@
+---
+layout: text/textblock
+section: Activities
+---
+[Content planning workshop](/sitemap)
+
+Use this planning workshop to shape a visual content plan that the broader team can understand.
+
+Once your plan is complete, use it inform everyone involved.
+
+[Content tasks and skills workshop 0KB PPTX](/sitemap)
+
+Use this workshop activity with your immediate or broader teams. Explore the tasks involved in each stage of the content lifecycle and the skills you need to execute those tasks.
+
+Invite all of the people who are involved in planning and creating, through to removing content.

--- a/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/facilitator-head.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/facilitator-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Facilitator's notes
+---

--- a/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/facilitator.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/facilitator.md
@@ -1,0 +1,61 @@
+---
+layout: text/textblock
+section: Facilitator’s notes
+---
+Use a whiteboard to explore the end-to-end content task. Alternatively, work together in a document.
+
+You can think about some or all of the points and questions listed below. Ask your team to contribute by adding post-it notes under whichever headings you need.
+
+## [2]User task/need
+- What does the user need to do or know?
+- Can users interpret what they can do, need to do or need to know from the content?
+- What will the user know when they have finished their task?
+
+## [2]Business goals
+- What is the purpose of the content or task?
+- Does it align with the corporate plan?
+- Is there a legal mandate to publish in a particular location?
+- Do you need to use specific terms or formats?
+- Is there a deadline?
+
+## [2]Findability
+- Where will the content sit in the information architecture (IA)?
+- Does it have a user-friendly title?
+- How does the user find the page/s?
+- Where does the user go next?
+
+## [2]Content decisions
+- Do you need to improve existing content or need to create content from scratch?
+- Is the suggested format what the user really needs and the best way to communicate your main messages?
+- Do you need to remove any outdated content?
+- Is this information or service only given by your agency?
+- Does it relate to what your agency does or is responsible for?
+
+## [2]Promotion
+- How will you promote the content from another part of the website or from other channels?
+- Will the content impact other channels such as social media, apps, shopfronts, call centres and outgoing letters?
+- Do you need multimedia, such as a video?
+- Have you factored in the time for including transcripts or closed captions?
+- Are you adding any content formats, for example infographics?
+
+## [2]Timeline
+- What time do you need to repurpose content for user needs?
+- What time do you need to to check that content meets the Content Guide and test it?
+- Will your timeline meet your deadline?
+
+## [2]Maintaining
+- Do you need the content for a set amount of time? If so, you could set up an automatic reminder in your content management system.
+- How will you maintain the content, including reviewing and improving it?
+- How will you remove the content when it is no longer relevant?
+
+## [2]Measurement
+- Do you need to measure the content’s performance?
+- What analytics tools are you using?
+- How often will you report on the content?
+- How will you measure it? Have you benchmarked your current content?
+
+## [2]Assign skills, checks and sign off
+- Subject matter expert
+- Web writing skills
+- Supporting specialists
+- Approver for final sign off

--- a/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/index.yml
+++ b/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/index.yml
@@ -1,0 +1,19 @@
+title: Content planning workshop
+weight: 60
+theme: blue
+header:
+  - /_shared/globalheader.md
+  - /_shared/header.md
+main:
+  - intro.md
+  - sections.md
+  - why-head.md
+  - why.md
+  - start-head.md
+  - start.md
+  - start-quote.md
+  - facilitator-head.md
+  - facilitator.md
+  - /_shared/feedback.md
+footer:
+  - /_shared/footer.md

--- a/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/intro.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/intro.md
@@ -1,0 +1,11 @@
+---
+layout: intros/intro_with_nav
+metaTitle1: Created by
+metaValue1: Digital Transformation Agency and Attorney-General's Department
+metaTitle2: Reviewed on
+metaValue2: 31 October 2017
+category: Governing content
+---
+Run a planning workshop to shape a content plan that the broader team can understand.
+
+[Understand the content lifecycle](/governing-content/understand-content-lifecycle/) Know how to use the stages of the content lifecycle to plan, create, test and improve your content’s usability.

--- a/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/sections.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/sections.md
@@ -1,0 +1,7 @@
+---
+layout: nav/sections
+sections:
+  - Why run a planning workshop?
+  - Start with a user focus
+  - Facilitator’s notes
+---

--- a/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/start-head.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/start-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Start with a user focus
+---

--- a/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/start-quote.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/start-quote.md
@@ -1,0 +1,4 @@
+---
+layout: text/quote
+quote: As a [who the user is] I need [something] so that I can [do something].
+---

--- a/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/start.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/start.md
@@ -1,0 +1,6 @@
+---
+layout: text/textblock
+section: Start with a user focus
+---
+Bring your team together to create an overarching user need. You can do this by creating a user story. Doing this at the start will give the team a focus for the session. It puts the user at the centre of what you are planning.
+For example:

--- a/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/why-head.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/why-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Why run a planning workshop?
+---

--- a/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/why.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/content-planning-workshop/why.md
@@ -1,0 +1,7 @@
+---
+layout: text/textblock
+section: Why run a planning workshop?
+---
+- Use a content planning workshop to help your team explore user needs and business expectations.
+- Gain a collective understanding of the approach you will take and how you will measure success.
+- Use your plan to direct content production tasks and expert checks.

--- a/content/governing-content/understand-content-lifecycle/planning-content/index.yml
+++ b/content/governing-content/understand-content-lifecycle/planning-content/index.yml
@@ -1,0 +1,20 @@
+title: Planning content
+weight: 10
+theme: blue
+header:
+  - /_shared/globalheader.md
+  - /_shared/header.md
+main:
+  - intro.md
+  - sections.md
+  - workflow-head.md
+  - workflow.md
+  - activities-head.md
+  - activities.md
+  - templates-head.md
+  - templates.md
+  - typical-tasks-head.md
+  - typical-tasks.md
+  - /_shared/feedback.md
+footer:
+  - /_shared/footer.md

--- a/content/governing-content/understand-content-lifecycle/planning-content/intro.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/intro.md
@@ -3,7 +3,7 @@ layout: intros/intro_with_nav
 subtitle: Plan to define the end-to-end content task so the broader team has clarity about user needs and business goals.
 category: Governing content
 ---
-## [2]Why plan content?
+## [3]Why plan content?
 - so writers and reviewers are clear about the purpose of the content
 - to understand the content in context of the digital ecosystem
 - to know what skills and people you need for each content task

--- a/content/governing-content/understand-content-lifecycle/planning-content/intro.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/intro.md
@@ -1,0 +1,10 @@
+---
+layout: intros/intro_with_nav
+subtitle: Plan to define the end-to-end content task so the broader team has clarity about user needs and business goals.
+category: Governing content
+---
+## [2]Why plan content?
+- so writers and reviewers are clear about the purpose of the content
+- to understand the content in context of the digital ecosystem
+- to know what skills and people you need for each content task
+- to set guidelines for checking, repurposing, maintenance and measurement

--- a/content/governing-content/understand-content-lifecycle/planning-content/sections.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/sections.md
@@ -1,0 +1,8 @@
+---
+layout: nav/sections
+sections:
+  - Workflow process
+  - Activities
+  - Templates
+  - Typical tasks
+---

--- a/content/governing-content/understand-content-lifecycle/planning-content/skills-head.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/skills-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Skills
+---

--- a/content/governing-content/understand-content-lifecycle/planning-content/skills.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/skills.md
@@ -1,0 +1,20 @@
+---
+layout: text/textblock
+section: Skills
+---
+Discover the skills you need for the end-to-end content task. You will most likely need people with the following skills.
+
+## [2]Subject matter expertise
+To contribute specialist knowledge, business perspectives and requirements
+
+## [2]Communications
+To plan for strategic communications across multiple channels
+
+## [2]Knowledge of the digital ecosystem
+- to identify related content in your website’s information architecture
+- to identify related content across other agency websites
+
+## [2]Writing for the web and accessibility
+- to contribute a user-focused perspective
+- to apply metadata knowledge
+- to put a maintenance process in place

--- a/content/governing-content/understand-content-lifecycle/planning-content/templates-head.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/templates-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Templates
+---

--- a/content/governing-content/understand-content-lifecycle/planning-content/templates.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/templates.md
@@ -1,0 +1,8 @@
+---
+layout: text/textblock
+section: Templates
+---
+
+[Content production template 0KB DOCX](/sitemap)
+
+Transfer the main messages from your planning workshop to the content production template. This will give context to authors and reviewers.

--- a/content/governing-content/understand-content-lifecycle/planning-content/typical-tasks-head.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/typical-tasks-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Typical tasks
+---

--- a/content/governing-content/understand-content-lifecycle/planning-content/typical-tasks.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/typical-tasks.md
@@ -1,0 +1,20 @@
+---
+layout: text/textblock
+section: Typical tasks
+---
+
+Know the end-to-end tasks involved.
+
+## [2] Discover the purpose of the content for the user
+Have a clear idea of what the user needs to do and the steps they need to take to find out what they need to know.
+
+## [2]Identify professional expertise
+- Find out which specialists you need from communications, marketing, web writing/editing and publishing.
+- Clarify what you need them to contribute.
+
+## [2]Check content lifecycle
+- What content already exists: can you repurpose it, remove it or update it?
+- How are you planning to maintain the content?
+
+## [2]Checks and sign offs
+Find out who is checking the content, what they are responsible for, and who has final sign off.

--- a/content/governing-content/understand-content-lifecycle/planning-content/workflow-head.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/workflow-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Workflow process
+---

--- a/content/governing-content/understand-content-lifecycle/planning-content/workflow.md
+++ b/content/governing-content/understand-content-lifecycle/planning-content/workflow.md
@@ -1,0 +1,9 @@
+---
+layout: text/textblock
+section: Workflow process
+---
+Planning focuses on building relationships.
+
+Work with clients and content requesters to gain a mutual understanding of business and user needs.
+
+Understand who is involved throughout the lifecycle stages.

--- a/content/governing-content/understand-content-lifecycle/publishing-content/index.yml
+++ b/content/governing-content/understand-content-lifecycle/publishing-content/index.yml
@@ -1,0 +1,18 @@
+title: Publishing content
+weight: 50
+theme: blue
+header:
+  - /_shared/globalheader.md
+  - /_shared/header.md
+main:
+  - intro.md
+  - sections.md
+  - workflow-head.md
+  - workflow.md
+  - skills-head.md
+  - skills.md
+  - typical-tasks-head.md
+  - typical-tasks.md
+  - /_shared/feedback.md
+footer:
+  - /_shared/footer.md

--- a/content/governing-content/understand-content-lifecycle/publishing-content/intro.md
+++ b/content/governing-content/understand-content-lifecycle/publishing-content/intro.md
@@ -1,0 +1,10 @@
+---
+layout: intros/intro_with_nav
+subtitle: Plan to define the end-to-end content task so the broader team has clarity about user needs and business goals.
+category: Governing content
+---
+## [3]Why plan content?
+- so writers and reviewers are clear about the purpose of the content
+- to understand the content in context of the digital ecosystem
+- to know what skills and people you need for each content task
+- to set guidelines for checking, repurposing, maintenance and measurement

--- a/content/governing-content/understand-content-lifecycle/publishing-content/sections.md
+++ b/content/governing-content/understand-content-lifecycle/publishing-content/sections.md
@@ -1,0 +1,7 @@
+---
+layout: nav/sections
+sections:
+  - Workflow process
+  - Skills
+  - Typical tasks
+---

--- a/content/governing-content/understand-content-lifecycle/publishing-content/skills-head.md
+++ b/content/governing-content/understand-content-lifecycle/publishing-content/skills-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Skills
+---

--- a/content/governing-content/understand-content-lifecycle/publishing-content/skills.md
+++ b/content/governing-content/understand-content-lifecycle/publishing-content/skills.md
@@ -1,0 +1,11 @@
+---
+layout: text/textblock
+section: Skills
+---
+Apply specific skills at the publishing stage of the content lifecycle to ensure usability.
+
+**Web publisher, content publisher, digital producer/developer, accessibility tester roles will typically apply:**
+- accessibility compliance with WCAG 2.0
+- accessibility assurance in the CMS
+- content writing and usability awareness
+- CMS and HTML expertise

--- a/content/governing-content/understand-content-lifecycle/publishing-content/typical-tasks-head.md
+++ b/content/governing-content/understand-content-lifecycle/publishing-content/typical-tasks-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Typical tasks
+---

--- a/content/governing-content/understand-content-lifecycle/publishing-content/typical-tasks.md
+++ b/content/governing-content/understand-content-lifecycle/publishing-content/typical-tasks.md
@@ -1,0 +1,14 @@
+---
+layout: text/textblock
+section: Typical tasks
+---
+Remember to allow time for publishing tasks to be done before sending live.
+
+**Web publisher, content publisher, digital producer/developer, accessibility tester roles will typically:**
+- set up and check redirects and short URLs
+- check link integrity
+- check for duplicate page titles
+- upload for accessibility in the platform
+- add content and metadata to the platform
+- add metrics code
+- add search engine code

--- a/content/governing-content/understand-content-lifecycle/publishing-content/workflow-head.md
+++ b/content/governing-content/understand-content-lifecycle/publishing-content/workflow-head.md
@@ -1,0 +1,4 @@
+---
+layout: nav/section
+section: Workflow process
+---

--- a/content/governing-content/understand-content-lifecycle/publishing-content/workflow.md
+++ b/content/governing-content/understand-content-lifecycle/publishing-content/workflow.md
@@ -1,0 +1,11 @@
+---
+layout: text/textblock
+section: Workflow process
+---
+Experts have already checked, tested and signed off content.
+
+Publishing teams focus on usability in the platform.
+
+Publishing teams are able to push back on inaccessible content.
+
+Content designers and strategists keep publishing teams up to date on standards for accessibility, style and usability.

--- a/content/governing-content/understand-content-lifecycle/stages-head.md
+++ b/content/governing-content/understand-content-lifecycle/stages-head.md
@@ -1,4 +1,0 @@
----
-layout: nav/section
-section: Content lifecycle stages
----

--- a/content/governing-content/understand-content-lifecycle/stages.md
+++ b/content/governing-content/understand-content-lifecycle/stages.md
@@ -1,9 +1,0 @@
----
-layout: text/textblock
-section: Content lifecycle stages
----
-- Planning content
-- Creating content
-- Checking and testing content
-- Signing off content
-- Publishing content


### PR DESCRIPTION
Add 3 new subtopics: 
- 'Planning content'
- 'Checking and testing content'
- ' Publishing content'

Add new sub-sub-topic:
- 'Content planning workshop'

Additional:
- Minor style adjustment to 'Planning content' 
- Remove redundant block from parent, 'Understand the content lifecycle'