### PR TITLE
Link and property clean up

### DIFF
--- a/content/content-strategy/accessible-content/accessible-content-articles.md
+++ b/content/content-strategy/accessible-content/accessible-content-articles.md
@@ -3,14 +3,14 @@ layout: cards/cards
 cards:
   - headline: Benefits of accessible content
     text: Web accessibility is a basic human right. Both our community and government benefit when we get it right.
-    link: '/content-strategy/accessible-content/benefits-accessible-content/'
+    link: 'benefits-accessible-content/'
   - headline: Consequences and risk
     text: Agencies are at risk from complaints to the Human Rights Commission. This may attract negative media attention.
-    link: '/content-strategy/accessible-content/consequences-risk/'
+    link: 'consequences-risk/'
   - headline: Changing the mindset
     text: Share the responsibility with senior managers. Invest in training. Put together a business case.
-    link: '/content-strategy/accessible-content/changing-mindset/'
+    link: 'changing-mindset/'
   - headline: Tips to improve accessibility
     text: Start by drawing a line in the sand between old practices and a new way forward.
-    link: '/content-strategy/accessible-content/tips-improve-accessibility/'
+    link: 'tips-improve-accessibility/'
 ---

--- a/content/content-strategy/accessible-content/index.yml
+++ b/content/content-strategy/accessible-content/index.yml
@@ -1,5 +1,6 @@
 title: Accessible content
 weight: 10
+hidden: true
 theme: blue
 header:
   - /_shared/globalheader.md

--- a/content/content-strategy/guides-cards.md
+++ b/content/content-strategy/guides-cards.md
@@ -10,9 +10,6 @@ cards:
   - headline: Removing content
     text: Remove unwanted, redundant and out-of-date content to help users find what they need.
     link: removing-content/    
-  - headline: Accessible content
-    text: The people who most need government services and information often find them the hardest to use. Think about creating content that is accessible for everyone from the start.
-    link: accessible-content/
   - headline: GOV.AU Content Guide
     text: This 'living' guide helps government teams create simple, clear and accessible digital content.
     link: https://guides.service.gov.au/content-guide/

--- a/content/content-strategy/information-architecture/index.yml
+++ b/content/content-strategy/information-architecture/index.yml
@@ -1,5 +1,6 @@
 title: Information architecture
 weight: 10
+hidden: true
 theme: blue
 header:
   - /_shared/globalheader.md

--- a/content/governing-content/understand-content-lifecycle/signing-off-content/index.yml
+++ b/content/governing-content/understand-content-lifecycle/signing-off-content/index.yml
@@ -1,5 +1,5 @@
 title: Signing off content
-weight: 20
+weight: 40
 theme: blue
 header:
   - /_shared/globalheader.md


### PR DESCRIPTION
For `Test`

- Cleaned links to 'Accessible content' topic(s)
- Delete only reference to main 'Accessible content' page: not ready for 31st
- Fix `weight` property on 'Signing off content' to correct the list order in menu 