### PR TITLE
Add alt long text description

### DIFF
--- a/content/governing-content/understand-content-lifecycle/content-decision-tree/image.md
+++ b/content/governing-content/understand-content-lifecycle/content-decision-tree/image.md
@@ -5,7 +5,26 @@ display: 3
 level: 2
 reverse: true
 stackPosition: top
-imageAlt: "Flow chart diagram."
+imageAlt: "Flow chart diagram, description follows."
 ---
 
-Read a long description of the content decision tree [link to come] diagram.
+Read a long description of the content decision tree flow chart.
+
+## [3]Title: Content decision tree
+
+Top of flow chart begins with Q: "Does the content meet your target audience’s need?"
+
+1. If 'Yes' to Q: "Does the content meet your target audience’s need?", then Q: "Is the content redundant, outdated or trivial?"
+    1. If ‘Yes’, then "Create a removal plan."
+    2. If ‘No’, then Q: "Do we own the content?"
+        1. If ‘No’, then "Link to third party site" and then "Publish".
+        2. If ‘Yes’, then Q: "Does the content meet accessibility and quality guidelines?"
+            1. If ‘Yes’, then "Publish".
+            2. If ‘No’, then "Rewrite content", then check it meets accessibility and quality guidelines, and then "Publish".
+2. If ‘No’ to Q: "Does the content meet your target audience’s need?", then Q: "Does the business have a policy/regulatory requirement to provide this content?"
+    1. If ‘No’, then "Create a removal plan."
+    2. If ‘Yes’, then Q: "Do we own the content?"
+        1. If ‘No’, then "Link to third party site" and then "Publish".
+        2. If ‘Yes’, then Q: "Does the content meet accessibility and quality guidelines?"
+            1. If ‘Yes’, then "Publish".
+            2. If ‘No’, then "Rewrite content", then check it meets accessibility and quality guidelines, and then "Publish".


### PR DESCRIPTION
I've left the long description on the same page and in the same partial as the image for now, as we are still working out how to handle the over all interaction for this @shad0wMe0w But we can easily create a new topic page and link to it.