### PR TITLE
pages with start of names that match pageId path bugfix

### DIFF
--- a/src/nav/nav.js
+++ b/src/nav/nav.js
@@ -35,7 +35,7 @@ const Navigation = ({
 				.map( ( pageID, i ) => {
 					const homepage = homepageName === '' ? Object.keys( nav )[ 0 ] : homepageName;
 					const page = nav[ pageID ];
-					const _displayItem =  noParents && pageID.startsWith( startID ) || level === 2 && childnav1lvl === true || !noParents;
+					const _displayItem =  noParents && (pageID.startsWith( startID ) && (pageID.charAt(startID.length) == '' || pageID.charAt(startID.length) == '/') ) || level === 2 && childnav1lvl === true || !noParents;
 
 					// We only pursue this element if it either
 					// starts with our startID or is the homepage if we got noParents = true


### PR DESCRIPTION
Bug fixes the issue when some page names may partially match the startOf the parentId, causing the page to be added to the childnav of category it is not part of.

New condition checks if there is more characters in the the page name, and if not it allows page in the childnav