### PR TITLE
Update formatting for examples, key takeaways and attachments

### DIFF
--- a/content/content-strategy/audit-content/action-audit/example2.md
+++ b/content/content-strategy/audit-content/action-audit/example2.md
@@ -1,4 +1,4 @@
 ---
-layout: text/callout
+layout: text/textblock
 ---
-Example audit summary: the [UK Government Digital Service content audit template](/assets/files/content-strategy/govuk-example-audit-sheet.xlsx) has a clear and simple automated summary on the first page.
+Example audit summary: the [UK Government Digital Service content audit template (XLSX, 44KB)](/assets/files/content-strategy/govuk-example-audit-sheet.xlsx) has a clear and simple automated summary on the first page.

--- a/content/content-strategy/audit-content/action-audit/index.yml
+++ b/content/content-strategy/audit-content/action-audit/index.yml
@@ -12,7 +12,7 @@ main:
   - toc.md #toc
   - heading.md #report findings
   - section.md #report findings
-  - example2.md #example
+  - example2.md #spreadsheet file attachment
   - heading2.md #remove content
   - section2.md #remove content
   - heading3.md #archive

--- a/content/content-strategy/audit-content/analyse-evaluate/example.md
+++ b/content/content-strategy/audit-content/analyse-evaluate/example.md
@@ -1,7 +1,7 @@
 ---
 layout: text/callout
 ---
-
+### Example
 Use these tools for your content audit:
   * website content analytics, such as Google Analytics
   * user research feedback tools, such as surveys and behaviour tracking

--- a/content/content-strategy/audit-content/analyse-evaluate/supporting-takeaway.md
+++ b/content/content-strategy/audit-content/analyse-evaluate/supporting-takeaway.md
@@ -1,5 +1,5 @@
 ---
 layout: text/callout
 ---
-
+### [3]Key takeaway
 Your analysis will help with evidence-based decision-making and be useful when talking with stakeholders.

--- a/content/content-strategy/audit-content/conduct-audit/example.md
+++ b/content/content-strategy/audit-content/conduct-audit/example.md
@@ -1,7 +1,7 @@
 ---
-layout: text/callout
+layout: text/textblock
 ---
-The templates below are examples that you can tailor to suit your needs.
-  * [NSW Department of Education: content audit spreadsheet](/assets/files/content-strategy/nsw-education-content-audit-spreadsheet.xlsx) (XLSX 191KB)
-  * [Department of Agriculture: content audit spreadsheet](/assets/files/content-strategy/agriculture-example-audit-spreadsheet.xlsx) (XLSX 146KB)
-  * [UK Government Digital Service: content audit spreadsheet](/assets/files/content-strategy/govuk-example-audit-sheet.xlsx) (XLSX 44KB)
+These templates are examples that you can tailor to suit your needs.
+  * [NSW Department of Education: content audit spreadsheet (XLSX, 191KB)](/assets/files/content-strategy/nsw-education-content-audit-spreadsheet.xlsx) 
+  * [Department of Agriculture: content audit spreadsheet (XLSX, 146KB)](/assets/files/content-strategy/agriculture-example-audit-spreadsheet.xlsx) 
+  * [UK Government Digital Service: content audit spreadsheet (XLSX, 44KB)](/assets/files/content-strategy/govuk-example-audit-sheet.xlsx) 

--- a/content/content-strategy/audit-content/conduct-audit/example2.md
+++ b/content/content-strategy/audit-content/conduct-audit/example2.md
@@ -1,6 +1,7 @@
 ---
 layout: text/callout
 ---
+### Example
 Use these kinds of audit tools when collating your content:
   * website content analytics, such as Google Analytics
   * readability checkers

--- a/content/content-strategy/audit-content/conduct-audit/index.yml
+++ b/content/content-strategy/audit-content/conduct-audit/index.yml
@@ -12,14 +12,14 @@ main:
   - toc.md #toc
   - heading.md
   - section.md
-  - example.md #example
+  - example.md #spreadsheet file attachments
   - heading2.md
   - section2.md
   - heading3.md
   - section3.md
   - heading4.md
   - section4.md
-  - example2.md #example
+  - example2.md #example callout
   - /_shared/feedback.md
 footer:
   - /_shared/footer.md

--- a/content/content-strategy/audit-content/plan-your-audit/example.md
+++ b/content/content-strategy/audit-content/plan-your-audit/example.md
@@ -2,7 +2,8 @@
 layout: text/callout
 ---
 
-### [1]Questions to ask
+### Example 
+Questions to ask:
   * Has the original purpose changed?
   * If the purpose has changed, is it confusing for people visiting the site to find what they need?
   * If people are no longer coming to that website should it be retired?

--- a/content/content-strategy/audit-content/plan-your-audit/supporting-takeaway.md
+++ b/content/content-strategy/audit-content/plan-your-audit/supporting-takeaway.md
@@ -1,5 +1,5 @@
 ---
 layout: text/callout
 ---
-
+#### Key takeaway
 If you are short of time and resources the most useful method is to audit a section of your website. You can scale back an audit, but still be methodical in your approach.

--- a/content/content-strategy/identify-business-needs/what-business-needs/goals-example.md
+++ b/content/content-strategy/identify-business-needs/what-business-needs/goals-example.md
@@ -1,5 +1,5 @@
 ---
 layout: text/callout
 ---
-
+#### Example
 To reduce gov.au domains by XX% by the year XXX

--- a/content/content-strategy/identify-business-needs/what-business-needs/mission-example.md
+++ b/content/content-strategy/identify-business-needs/what-business-needs/mission-example.md
@@ -1,5 +1,5 @@
 ---
 layout: text/callout
 ---
-
+#### Example
 We enable government agencies to deliver user-centred content more efficiently.

--- a/content/content-strategy/identify-business-needs/what-business-needs/objectives-example.md
+++ b/content/content-strategy/identify-business-needs/what-business-needs/objectives-example.md
@@ -1,5 +1,5 @@
 ---
 layout: text/callout
 ---
-
+#### Example
 XX agencies have joined the whole of government content strategy working group.

--- a/content/content-strategy/identify-business-needs/what-business-needs/strategies-example.md
+++ b/content/content-strategy/identify-business-needs/what-business-needs/strategies-example.md
@@ -1,5 +1,5 @@
 ---
 layout: text/callout
 ---
-
+#### Example
 To provide a strategic content framework and best practice guidance to empower and equip agencies.

--- a/content/content-strategy/identify-business-needs/what-business-needs/tactics-example.md
+++ b/content/content-strategy/identify-business-needs/what-business-needs/tactics-example.md
@@ -1,5 +1,5 @@
 ---
 layout: text/callout
 ---
-
+#### Example
 To provide tactical solutions. Tactics are the plan for delivering your strategy.

--- a/content/content-strategy/identify-business-needs/what-business-needs/vision-example.md
+++ b/content/content-strategy/identify-business-needs/what-business-needs/vision-example.md
@@ -1,5 +1,5 @@
 ---
 layout: text/callout
 ---
-
+#### Example
 Government services are transformed to better meet user needs.

--- a/content/content-strategy/start-content-strategy/show-problem-evidence/example.md
+++ b/content/content-strategy/start-content-strategy/show-problem-evidence/example.md
@@ -1,4 +1,5 @@
 ---
 layout: text/callout
 ---
+#### Example
 Since we reduced 45% of pages on the Department of X website, the number of online transactions increased by 30% and call centre contacts reduced by 25%. This saved the agency $X.

--- a/content/content-strategy/start-content-strategy/tips-pitching-case/example.md
+++ b/content/content-strategy/start-content-strategy/tips-pitching-case/example.md
@@ -1,5 +1,5 @@
 ---
 layout: text/callout
 ---
-
+### Example
 We need a content strategy for our agency to help users find what they need on the channel they’re on, so that we create usable content and decrease channel hopping.

--- a/content/content-strategy/start-content-strategy/tips-pitching-case/supporting-takeaway.md
+++ b/content/content-strategy/start-content-strategy/tips-pitching-case/supporting-takeaway.md
@@ -1,6 +1,7 @@
 ---
 layout: text/callout
 ---
+### Key takeaway
 Numbers are a powerful, persuasive tool. Create a ‘shock and awe’ slide that pulls together data that shows the cost of poor content. 
 
 For example, this could be the time spent by call centres answering website queries. Or it  could be the time spent getting approval for a piece of content in a poor workflow.

--- a/content/content-strategy/urgent-content-requests/prepare-urgent-request/supporting-takeaway.md
+++ b/content/content-strategy/urgent-content-requests/prepare-urgent-request/supporting-takeaway.md
@@ -1,4 +1,5 @@
 ---
 layout: text/callout
 ---
+### Key takeaway
 You might like to hold a [Content planning workshop](/content-strategy/manage-content-requests/plan-content/content-planning-workshop) with your clients or stakeholders.

--- a/content/digital-service-standard/why02.md
+++ b/content/digital-service-standard/why02.md
@@ -10,6 +10,6 @@ imageAlt: "Stack of DTA posters: 2 showing the Digital Service Standard and 2 wi
 ---
 Use these posters to help your team keep the Digital Service Standard top of mind:
 
-- [Digital Service Standard poster 110KB PDF](/assets/files/standard/digital-service-criteria-2017-poster.pdf)
-- [Digital Service Standard kanban poster 116KB PDF](/assets/files/standard/digital-service-standard-kanban-poster.pdf)
-- [Workplace culture posters 109KB PDF](/assets/files/design-principles/dta-culture-posters.pdf)
+- [Digital Service Standard poster (PDF, 110KB)](/assets/files/standard/digital-service-criteria-2017-poster.pdf)
+- [Digital Service Standard kanban poster (PDF, 116KB)](/assets/files/standard/digital-service-standard-kanban-poster.pdf)
+- [Workplace culture posters (PDF, 109KB)](/assets/files/design-principles/dta-culture-posters.pdf)

--- a/content/service-design-delivery-process/what.md
+++ b/content/service-design-delivery-process/what.md
@@ -11,4 +11,4 @@ The service design and delivery process is an agile approach. It helps the team 
 
 The service design and delivery process guides the team to build a user-centred service that is simple, fast and clear.
 
-Download the [service design and delivery process poster 229KB PDF](../assets/files/service-design-delivery-process/service-design-delivery-process-poster.pdf).
+Download the [service design and delivery process poster (PDF, 229KB)](../assets/files/service-design-delivery-process/service-design-delivery-process-poster.pdf).


### PR DESCRIPTION
Added ‘Example’ at correct level heading for all example partials that did not contain attachments.
Added ‘Key takeaway’ at correct heading level to all partials flagged as supporting takeaways.
Removed callout style for two “examples” that actually referred to file attachments. The attachment link format is now consistent across the site. Well, there are 2 or 3 file attachments wrapped in cards at the moment. The formatting for those will be handled in a separate PR.
[file description/name] + [(fileType, fileSize)]