### PR TITLE
Rename CS label on the global nav

### DIFF
--- a/content/_shared/mainmenu.md
+++ b/content/_shared/mainmenu.md
@@ -16,6 +16,6 @@ navigation:
           link: /starting-team
         - text: User research
           link: /user-research
-        - text: Content Strategy
+        - text: Content Strategy Guide
           link: /content-strategy
 ---


### PR DESCRIPTION
‘Content Strategy’ label is now ‘Content Strategy Guide’ in global nav to be consistent with rename elsewhere; improvement based on previous round of user research.