### PR TITLE
Minor style tweaks

### DIFF
--- a/src/sass/components/topics_cards.scss
+++ b/src/sass/components/topics_cards.scss
@@ -19,7 +19,6 @@ h2.topics__header {
 
 .topicscards__tagline {
 	margin-top: 1.5rem;
-	font-weight: 300;
 	@include AU-media( md ) {
 		max-width: 90%;
 	}
@@ -27,7 +26,6 @@ h2.topics__header {
 
 h2.topicscards__headline {
 	max-width: 90%;
-	font-weight: 500;
 }
 
 .topicscards__viewall {


### PR DESCRIPTION
Removed custom font-weights for topics cards tagline and h2s: now consistent with body and h2 content on adjacent pages on the site.

Weights inherit from the body and h2 styles which are fine in these cases.