### PR TITLE
Allow only one mobile menu tab to be open at once

### DIFF
--- a/scripts/js/020-components/04-mainmenu.js
+++ b/scripts/js/020-components/04-mainmenu.js
@@ -10,11 +10,20 @@ var focustrapBottom = document.getElementById( 'focustrap-bottom' );
 var mainmenuLinks   = document.querySelectorAll( '.header a, .header button' );
 var navSkipLink     = document.querySelectorAll( '.au-skip-link__link[href="#mainmenu"]' )[ 0 ];
 
+function CloseMenuOnly() {
+	AU.accordion.Close(mainmenuToggle, undefined);
+	mainmenuToggle.innerHTML = 'Open menu';							// Change the text in the toggle
+}
 
+function CloseSearchOnly() {
+	AU.accordion.Close(searchToggle, undefined);
+	searchToggle.innerHTML = 'Open search';         
+}
 
 function ToggleMenu() {
 	AU.accordion.Toggle( mainmenuToggle, undefined, {
 		onOpen: function() {
+			CloseSearchOnly();															 // Force close the search in case it's currently open
 			mainmenuToggle.innerHTML = 'Close menu';         // Change the text in the toggle
 			focustrapTop.setAttribute( "tabindex", 0 );      // Enable the focus trap
 			focustrapBottom.setAttribute( "tabindex", 0 );
@@ -32,6 +41,7 @@ function ToggleMenu() {
 function ToggleSearch() {
 	AU.accordion.Toggle( searchToggle, undefined, {
 		onOpen: function() {
+			CloseMenuOnly();																 // Force close the menu in case it's currently open
 			searchToggle.innerHTML = 'Close search';         // Change the text in the toggle
 			focustrapTop.setAttribute( "tabindex", 0 );      // Enable the focus trap
 			focustrapBottom.setAttribute( "tabindex", 0 );


### PR DESCRIPTION
Add extra logic to close other menu tab in case there’s one already open.
Want to optimise the functions in next iteration. I reckon there's probably a more elegant way to specify the open and close fn overrides.