### PR TITLE
Increase height of search overlay for mobile

### DIFF
--- a/src/sass/components/searchheader.scss
+++ b/src/sass/components/searchheader.scss
@@ -26,5 +26,5 @@
 }
 
 .search__searchbox {
-	@include AU-space( margin-bottom, 1unit );
+	@include AU-space( margin-bottom, 1.5unit );
 }


### PR DESCRIPTION
The slight bottom margin increase masks the side-nav accordion so that it isn’t accidentally triggered when user attempts to focus on the search box