### PR TITLE
Remove TOC items to sections that were previously removed

### DIFF
--- a/content/topics/service-design-delivery-process/alpha-stage/TOC.md
+++ b/content/topics/service-design-delivery-process/alpha-stage/TOC.md
@@ -12,5 +12,4 @@ sections:
   - Moving on to Beta stage
   - Deciding not to move on to Beta stage
   - Deciding to start a new Alpha stage
-  - Case studies and examples
 ---

--- a/content/topics/service-design-delivery-process/beta-stage/sections.md
+++ b/content/topics/service-design-delivery-process/beta-stage/sections.md
@@ -10,5 +10,4 @@ sections:
   - How long the Beta stage takes
   - How you know Beta stage is finished
   - When you’re ready to move on to Live stage
-  - Case studies and examples
 ---

--- a/content/topics/user-research/find-user-research-participants/sections.md
+++ b/content/topics/user-research/find-user-research-participants/sections.md
@@ -5,5 +5,4 @@ sections:
   - Finding participants
   - How to write a recruitment brief
   - Make your research inclusive
-  - Case studies and examples
 ---


### PR DESCRIPTION
The TOC links were still being displayed despite the content no longer being present