### PR TITLE
Use Node v10 for CircleCI and deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run: npm run build             # required build step
       # broken link check
       - run: sudo npm install -g broken-link-checker
-      - run: sudo npm install -g http-server
+      - run: sudo npm install -g http-server@13.0.2
       - run: http-server ./site > http.log 2>&1 & sleep 5 && sudo blc -r --exclude "/content-guide" --exclude-external http://localhost:8080
       # delete node_modules folder again to not push it to cf
       - run: rm -rf node_modules
@@ -74,7 +74,7 @@ jobs:
       - run: npm run build
       # broken link check
       - run: sudo npm install -g broken-link-checker
-      - run: sudo npm install -g http-server
+      - run: sudo npm install -g http-server@13.0.2
       - run: http-server ./site > http.log 2>&1 & sleep 5 && sudo blc -r --exclude "/content-guide" --exclude-external http://localhost:8080
       # delete node_modules folder again to not push it to cf
       - run: rm -rf node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   # installing dependencies, building assets and deploying to staging
   deploy-staging:
     docker:
-      - image: circleci/node:lts-stretch
+      - image: circleci/node:10-stretch
 
     steps:
       - checkout                       # get the files from the repo
@@ -39,7 +39,7 @@ jobs:
   # installing dependencies, building assets and deploying to production
   deploy-prod:
     docker:
-      - image: circleci/node:lts-stretch
+      - image: circleci/node:10-stretch
 
     steps:
       - checkout
@@ -65,7 +65,7 @@ jobs:
   # installing dependencies, building assets and deploying to test branches
   deploy-test:
     docker:
-      - image: circleci/node:lts-stretch
+      - image: circleci/node:10-stretch
 
     steps:
       - checkout

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -1,6 +1,6 @@
 ---
 host: guides
-buildpack: nodejs_buildpack
+buildpack: nodejs10_buildpack
 memory: 256M
 instances: 3
 env:

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -1,6 +1,6 @@
 ---
 host: service-manual
-buildpack: nodejs_buildpack
+buildpack: nodejs10_buildpack
 memory: 256M
 instances: 3
 env:

--- a/manifest-testing.yml
+++ b/manifest-testing.yml
@@ -1,5 +1,5 @@
 ---
-buildpack: nodejs_buildpack
+buildpack: nodejs10_buildpack
 memory: 256M
 instances: 1
 env:


### PR DESCRIPTION
This pull request updates CircleCI config to use Node v10 images and a version of `http-server` with support for Node v10.  Manifests have been updated as well to use the Node v10 buildpack.